### PR TITLE
Fixed the signInWithFacebook()

### DIFF
--- a/lib/services/auth.dart
+++ b/lib/services/auth.dart
@@ -88,18 +88,18 @@ class Auth implements AuthBase {
       FacebookPermission.email,
     ]);
     switch (response.status) {
-      case FacebookLoginStatus.Success:
+      case FacebookLoginStatus.success:
         final accessToken = response.accessToken;
         final userCredential = await _firebaseAuth.signInWithCredential(
           FacebookAuthProvider.credential(accessToken.token),
         );
         return userCredential.user;
-      case FacebookLoginStatus.Cancel:
+      case FacebookLoginStatus.cancel:
         throw FirebaseAuthException(
           code: 'ERROR_ABORTED_BY_USER',
           message: 'Sign in aborted by user',
         );
-      case FacebookLoginStatus.Error:
+      case FacebookLoginStatus.error:
         throw FirebaseAuthException(
           code: 'ERROR_FACEBOOK_LOGIN_FAILED',
           message: response.error.developerMessage,


### PR DESCRIPTION
The `FacebookLoginStatus` enum should be in lower case instead of uppercase

```dart
@override
  Future<User> signInWithFacebook() async {
    final fb = FacebookLogin();
    final response = await fb.logIn(permissions: [
      FacebookPermission.publicProfile,
      FacebookPermission.email,
    ]);
    switch (response.status) {
      case FacebookLoginStatus.success:
        final accessToken = response.accessToken;
        final userCredential = await _firebaseAuth.signInWithCredential(
          FacebookAuthProvider.credential(accessToken.token),
        );
        return userCredential.user;
      case FacebookLoginStatus.cancel:
        throw FirebaseAuthException(
          code: 'ERROR_ABORTED_BY_USER',
          message: 'Sign in aborted by user',
        );
      case FacebookLoginStatus.error:
        throw FirebaseAuthException(
          code: 'ERROR_FACEBOOK_LOGIN_FAILED',
          message: response.error.developerMessage,
        );
      default:
        throw UnimplementedError();
    }
  }
```